### PR TITLE
Skip ':' inside SHA1 signatures in WiFiClientSecure.cpp .

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -327,7 +327,7 @@ bool WiFiClientSecure::verify(const char* fp, const char* url) {
     int len = strlen(fp);
     int pos = 0;
     for (size_t i = 0; i < sizeof(sha1); ++i) {
-        while (pos < len && fp[pos] == ' ') {
+        while (pos < len && ((fp[pos] == ' ') || (fp[pos] == ':'))) {
             ++pos;
         }
         if (pos > len - 2) {


### PR DESCRIPTION
Improves the convenience of the verification of fingerprints.
As ':' are commonly inserted by web browser inside the SHA1 of https web sites, this created false problems with signatures "not matching".
Now, copied and pasted signature from Firefox simply because the verify function will skipped them...